### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This is so Mac users using GitHub Desktop are not notified about needing to update this repo whenever Mac automatically generates invisible metadata files.